### PR TITLE
Add permissions for serial devices (fixes #32)

### DIFF
--- a/nut/rootfs/etc/fix-attrs.d/nut
+++ b/nut/rootfs/etc/fix-attrs.d/nut
@@ -1,4 +1,6 @@
 /dev/bus/usb/*/* false root 0777 0777
+/dev/tty* false root 0777 0777
+/dev/serial/*/* false root 0777 0777
 /etc/nut/* true root:nut 0660 0660
 /usr/bin/notify false root 0755 0755
 /usr/bin/shutdownhost false root 0755 0755


### PR DESCRIPTION
# Proposed Changes

Adds permissions fix for `/dev/tty*` devices and devices in `/dev/serial`. I tested with only the `/dev/tty*` line and it seems that the `/dev/serial` line is necessary.

This is following a discussion on Discord with @sinclairpaul. Basically I had been running an old local version of this addon (from before it was made available in the community repo and before `auto_uart` was added or the auto-config file updates worked) and was trying to upgrade it. I went back through it and found I made this change to make it work.

## Related Issues

#32