### PR TITLE
Add example to use NUT event to push status update

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,21 @@ automations:
               volume: 1.0
 ```
 
+If you are using the NUT integration in Home Assistant, then you can also use this event to trigger it to push/update the status in realtime:
+
+```yaml
+automations:
+  - alias: 'UPS Pushed State Update'
+    trigger:
+    - platform: event
+      event_type: nut.ups_event
+    action:
+    - service: homeassistant.update_entity
+      data:
+      entity_id:
+      - sensor.my_ups_status
+```
+
 For more information, see the NUT docs [here][nut-notif-doc-1] and
 [here][nut-notif-doc-2].
 


### PR DESCRIPTION
# Proposed Changes

Let users know that they can use the event to force the NUT integration to update in realtime (like push updates).

## Related Issues

https://community.home-assistant.io/t/nut-trigger-update-event/197937

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<blockquote><img src="https://community-home-assistant-assets.s3.dualstack.us-west-2.amazonaws.com/original/3X/8/0/80d3f33958a234aab5cb9364b998048064d12b9d.png" width="48" align="right"><div><img src="https://community-home-assistant-assets.s3.dualstack.us-west-2.amazonaws.com/optimized/3X/f/4/f42b82971fce994297fbc2b269efa248beef897b_2_32x32.png" height="14"> Home Assistant Community</div><div><strong><a href="https://community.home-assistant.io/t/nut-trigger-update-event/197937">NUT trigger update event</a></strong></div><div>One thing that would be nice for the NUT integration would be a service to force a refresh of the UPS state. Something like nut.update. Maybe by default it would fetch the state of all UPSes and with a name field or something like that it would fetch just one.  This way, automations can be written so that whenever the NUT Addon sends the nut.ups_event event (https://github.com/hassio-addons/addon-nut#event-notifications), the UPS state will be updated (effectively pushed). Additionally, non-addo...</div></blockquote>