### PR TITLE
🚑Overwrite musl version

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -8,6 +8,7 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
+        musl@edge=1.2.1-r0 \
         hwids@edge=20200306-r0 \
         usbutils@edge=012-r1 \
         nut@edge=2.7.4-r6 \


### PR DESCRIPTION
# Proposed Changes

Move musl version to edge.

I believe Alpine is currently changing musl version's which lead to the issue (as a side note I don't believe it is supported to mix branches for packages).  Tested under armv7(32 bit) and x64, don't believe the bug reports for x64 are accurate as this should likely only affect 32 bit O/S's.

Pushing as a PR to get further feedback.

## Related Issues

#46 