### PR TITLE
🚑Implement local nut build

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -48,7 +48,9 @@ RUN \
             --with-statepath=/var/run/nut \
             --with-altpidpath=/var/run/nut \
     && make install \
+    && apk del --no-cache --purge .build-dependencies \
     && rm -f -r \
+        /tmp/* \
         /etc/nut/*.apk-new
 
 # Build arguments

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -19,6 +19,35 @@ RUN \
         neon-dev=0.31.1-r0 \
         net-snmp-dev=5.8-r3 \
     \
+    && curl -J -L -o /tmp/nut.tar.gz \
+        http://www.networkupstools.org/source/2.7/nut-2.7.4.tar.gz \
+    && mkdir -p /tmp/nut \
+    && tar zxf /tmp/nut.tar.gz -C \
+        /tmp/nut --strip-components=1 \
+    && cd /tmp/nut \
+    && ./configure \
+            --prefix=/usr \
+            --libexecdir=/usr/lib/nut \
+            --without-wrap \
+            --with-user=root \
+            --with-group=root \
+            --disable-static \
+            --with-serial \
+            --with-usb \
+            --without-avahi \
+            --with-snmp \
+            --with-neon \
+            --without-powerman \
+            --without-ipmi \
+            --without-freeipmi \
+            --with-libltdl \
+            --without-cgi \
+            --with-drvpath=/usr/lib/nut \
+            --datadir=/usr/share/nut \
+            --sysconfdir=/etc/nut \
+            --with-statepath=/var/run/nut \
+            --with-altpidpath=/var/run/nut \
+    && make install \
     && rm -f -r \
         /etc/nut/*.apk-new
 

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -10,6 +10,14 @@ RUN \
     apk add --no-cache \
         hwids=20200306-r0 \
         usbutils=012-r1 \
+    && apk add --no-cache --virtual .build-dependencies \
+        autoconf=2.69-r2 \
+        automake=1.16.2-r0 \
+        build-base=0.5-r2 \
+        libtool=2.4.6-r7 \
+        libusb-compat-dev=0.1.5-r4 \
+        neon-dev=0.31.1-r0 \
+        net-snmp-dev=5.8-r3 \
     \
     && rm -f -r \
         /etc/nut/*.apk-new

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -8,9 +8,8 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
-        hwids@edge=20200306-r0 \
-        usbutils@edge=012-r1 \
-        nut@edge=2.7.4-r6 \
+        hwids=20200306-r0 \
+        usbutils=012-r1 \
     \
     && rm -f -r \
         /etc/nut/*.apk-new

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -2,9 +2,6 @@ ARG BUILD_FROM=hassioaddons/base:8.0.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
-# Copy root filesystem
-COPY rootfs /
-
 # Setup base
 RUN \
     apk add --no-cache \
@@ -52,6 +49,9 @@ RUN \
     && rm -f -r \
         /tmp/* \
         /etc/nut/*.apk-new
+
+# Copy root filesystem
+COPY rootfs /
 
 # Build arguments
 ARG BUILD_ARCH

--- a/nut/rootfs/etc/fix-attrs.d/nut
+++ b/nut/rootfs/etc/fix-attrs.d/nut
@@ -1,5 +1,5 @@
-/etc/nut/* true root:nut 0660 0660
+/etc/nut/* true root 0660 0660
 /usr/bin/notify false root 0755 0755
 /usr/bin/shutdownhost false root 0755 0755
 /usr/bin/wall false root 0755 0755
-/var/run/nut false root:nut 0770 0770
+/var/run/nut false root 0770 0770


### PR DESCRIPTION
# Proposed Changes

Build NUT locally, to resolve issues with current Alpine Edge and 32 bit ARM

Tested on x64 and ARMv7 32 bit.

Referenced the Alpine build, while changing the user (root vs nut), and removed OpenSSL support, as there appears to be issues relating to it (likely due to the age), plus it requires certs setup in the container which would not have been done.

Really needs further testing, as I can only currently test using the Dummy driver.

## Related Issues

#46 