### PR TITLE
🔨 Add nut-xml driver

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     && apt-get install -y --no-install-recommends\
         nut=2.7.4-8 \
         nut-snmp=2.7.4-8 \
+        nut-xml=2.7.4-8 \
         usbutils=1:010-3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Proposed Changes

Add nut-xml driver, was present prior to switching to Debian

