### PR TITLE
Use multi-stage Dockerfile to build nut from master

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -1,21 +1,71 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:5.2.2
 # hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+FROM ${BUILD_FROM} as builder
 
+# Setup builder
+# hadolint ignore=DL3003
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential \
+       git \
+       python \
+       autoconf \
+       automake \
+       libtool \
+       libneon27-dev \
+       libsnmp-dev \
+       libusb-dev \
+       libltdl-dev
+
+RUN git clone https://github.com/networkupstools/nut.git \
+    && cd nut \
+    && ./autogen.sh \
+    && ./configure \
+            --prefix=/usr \
+            --libexecdir=/usr/lib/nut \
+            --without-wrap \
+            --with-user=root \
+            --with-group=root \
+            --disable-static \
+            --with-serial \
+            --with-usb \
+            --without-avahi \
+            --with-snmp \
+            --with-neon \
+            --without-powerman \
+            --without-ipmi \
+            --without-freeipmi \
+            --with-libltdl \
+            --without-cgi \
+            --with-drvpath=/usr/lib/nut \
+            --datadir=/usr/share/nut \
+            --sysconfdir=/etc/nut \
+            --with-statepath=/var/run \
+            --with-altpidpath=/var/run \
+    && make DESTDIR=/app install \
+    && make DESTDIR=/app install-conf
+
+FROM ${BUILD_FROM}
 # Setup base
 # hadolint ignore=DL3003
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends\
-        nut=2.7.4-13 \
-        nut-snmp=2.7.4-13 \
-        nut-xml=2.7.4-13 \
-        usbutils=1:013-3 \
+       usbutils \
+       libtool \
+       libneon27-gnutls \
+       libfreeipmi17 \
+       openssl \
+       libipmimonitoring6 \
+       libsnmp-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy root filesystem
 COPY rootfs /
+
+# Copy nut files from builder
+COPY --from=builder /app /
 
 # Build arguments
 ARG BUILD_ARCH


### PR DESCRIPTION
Use staging to build nut from master

# Proposed Changes

The current nut release (2.7.4) is well behind the master branch and is missing support for many UPS. This PR seeks to remedy this by building nut from source in a builder container before copying the files into the final container. This hopefully keeps the container at a comparable size while adding support for newer UPS.

## Related Issues

None

## Testing

I have only tested this build on amd64; multi-arch build would still need to be tested.
