### PR TITLE
🔨 Add pollfreq and pollfreqalert config options for upsmon

### DIFF
--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -225,6 +225,21 @@ specific drivers, should not be changed for the majority of users.
 Allows setting the DEADTIME value in upsmon.conf to adjust the stale time for
 the monitor process, should not be changed for the majority of users.
 
+### Option: `upsmon_pollfreq`
+
+Allows setting the POLLFREQ value in upsmon.conf to adjust poll frequency for
+the monitor process. By default, upsmon uses 5 seconds. If this is flooding
+your network with activity, you can make it higher.
+You can also make it lower to get faster notification events in some cases.
+
+### Option: `upsmon_pollfreqalert`
+
+Allows setting the POLLFREQALERT value in upsmon.conf to adjust poll frequency
+if any of its UPSes are on battery. You can use this along with POLLFREQ
+above to slow down polls during normal behavior, but get quicker updates
+when something bad happens. This should always be equal to or lower than
+the POLLFREQ value. By default it is also set yo 5 seconds.
+
 ### Option: `i_like_to_be_pwned`
 
 Adding this option to the add-on configuration allows to you bypass the

--- a/nut/config.yaml
+++ b/nut/config.yaml
@@ -62,5 +62,7 @@ schema:
   remote_ups_user: str?
   upsd_maxage: int?
   upsmon_deadtime: int?
+  upsmon_pollfreq: int?
+  upsmon_pollfreqalert: int?
   i_like_to_be_pwned: bool?
   leave_front_door_open: bool?

--- a/nut/rootfs/etc/cont-init.d/nutclient.sh
+++ b/nut/rootfs/etc/cont-init.d/nutclient.sh
@@ -4,6 +4,8 @@
 # Configures Network UPS Tools for Client Mode only
 # ==============================================================================
 declare deadtime=15
+declare pollfreq=5
+declare pollfreqalert=5
 declare -a CONF_ENTRIES=("name" "host" "password" "user")
 
 if bashio::config.equals 'mode' 'netclient' ;then
@@ -26,4 +28,14 @@ if bashio::config.has_value "upsmon_deadtime"; then
     deadtime=$(bashio::config "upsmon_deadtime")
 fi
 
+if bashio::config.has_value "upsmon_pollfreq"; then
+    pollfreq=$(bashio::config "upsmon_pollfreq")
+fi
+
+if bashio::config.has_value "upsmon_pollfreqalert"; then
+    pollfreqalert=$(bashio::config "upsmon_pollfreqalert")
+fi
+
 echo "DEADTIME ${deadtime}" >> /etc/nut/upsmon.conf
+echo "POLLFREQ ${pollfreq}" >> /etc/nut/upsmon.conf
+echo "POLLFREQALERT ${pollfreqalert}" >> /etc/nut/upsmon.conf

--- a/nut/rootfs/etc/nut/upsmon.conf
+++ b/nut/rootfs/etc/nut/upsmon.conf
@@ -135,7 +135,7 @@ NOTIFYCMD /usr/bin/notify
 # Adjust this to keep upsmon from flooding your network, but don't make
 # it too high or it may miss certain short-lived power events.
 
-POLLFREQ 5
+# POLLFREQ 5
 
 # --------------------------------------------------------------------------
 # POLLFREQALERT <n>
@@ -148,7 +148,7 @@ POLLFREQ 5
 #
 # The default is 5 seconds for both this and POLLFREQ.
 
-POLLFREQALERT 5
+# POLLFREQALERT 5
 
 # --------------------------------------------------------------------------
 # HOSTSYNC - How long upsmon will wait before giving up on another upsmon


### PR DESCRIPTION
# Proposed Changes

Similarly as in #94, this allows to set POLLFREQ and POLLFREQALERT options in [upsmon.conf](https://networkupstools.org/docs/man/upsmon.conf.html), in order to change poll time of upsmon. 

As a result, on can get notification events to HA faster/later then in the currently hardcoded 5 seconds.
