### PR TITLE
Upgrade to NUT 2.8.0

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -1,18 +1,13 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:6.1.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:12.2.3
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
 # Setup base
 # hadolint ignore=DL3003
 RUN \
-    apt-get update \
-    && apt-get install -y --no-install-recommends\
-        nut=2.7.4-13 \
-        nut-snmp=2.7.4-13 \
-        nut-xml=2.7.4-13 \
-        usbutils=1:013-3 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    apk add --no-cache \
+        nut=2.8.0-r0 \
+        usbutils=014-r0
 
 # Copy root filesystem
 COPY rootfs /

--- a/nut/build.yaml
+++ b/nut/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base:6.1.0
-  amd64: ghcr.io/hassio-addons/debian-base:6.1.0
-  armhf: ghcr.io/hassio-addons/debian-base:6.1.0
-  armv7: ghcr.io/hassio-addons/debian-base:6.1.0
-  i386: ghcr.io/hassio-addons/debian-base:6.1.0
+  aarch64: ghcr.io/hassio-addons/base:12.2.3
+  amd64: ghcr.io/hassio-addons/base:12.2.3
+  armhf: ghcr.io/hassio-addons/base:12.2.3
+  armv7: ghcr.io/hassio-addons/base:12.2.3
+  i386: ghcr.io/hassio-addons/base:12.2.3
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes

> Changed the base image to Alpine, in order to upgrade NUT to version 2.8.0. The new version of NUT supports more devices (for example my Legrand UPS).

I was not able to test the integration in Home Assistant. For some reason local addons won't show up. It will build though.

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
