### PR TITLE
Set maximum number of connections to 1024

### DIFF
--- a/nut/rootfs/etc/nut/upsd.conf
+++ b/nut/rootfs/etc/nut/upsd.conf
@@ -55,6 +55,8 @@ LISTEN 0.0.0.0
 # runs out of connections, it will no longer accept new incoming client
 # connections.  Only set this if you know exactly what you're doing.
 
+MAXCONN 1024
+
 # =======================================================================
 # CERTFILE <certificate file>
 # CERTFILE /usr/local/ups/etc/upsd.pem


### PR DESCRIPTION
# Proposed Changes

This avoids upsd allocating an excessive amount of memory (8GB). This is problematic on platforms which have more strict memory overcommitting policies (e.g. currently HAOS 10.0.rc2).

## Related Issues

Fixes #289 
