### PR TITLE
Add support for nut's powervalue config per-device

### DIFF
--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -143,6 +143,14 @@ specific drivers.
 This is the serial port where the UPS is connected. The first serial port
 usually is `/dev/ttyS0`. Use `auto` to automatically detect the port.
 
+#### Sub-option: `powervalue`
+
+Optionally lets you set whether this particular UPS provides power to the
+device this add-on is running on. Useful if you have multiple UPS that you
+wish to monitor, but you don't want low battery on some of them to shut down
+this host. Acceptable values are `1` for "providing power to this host" or `0`
+for "monitor only". Defaults to `1`
+
 #### Sub-option: `config`
 
 A list of additional [options][ups-fields] to configure for this UPS. The common

--- a/nut/config.yaml
+++ b/nut/config.yaml
@@ -51,7 +51,7 @@ schema:
     - name: str
       driver: str
       port: str
-      powervalue: list(0|1)?
+      powervalue: int?
       config:
         - str
   mode: list(netserver|netclient)

--- a/nut/config.yaml
+++ b/nut/config.yaml
@@ -51,6 +51,7 @@ schema:
     - name: str
       driver: str
       port: str
+      powervalue: list(0|1)?
       config:
         - str
   mode: list(netserver|netclient)

--- a/nut/rootfs/etc/cont-init.d/nut.sh
+++ b/nut/rootfs/etc/cont-init.d/nut.sh
@@ -80,6 +80,11 @@ if bashio::config.equals 'mode' 'netserver' ;then
         upsname=$(bashio::config "devices[${device}].name")
         upsdriver=$(bashio::config "devices[${device}].driver")
         upsport=$(bashio::config "devices[${device}].port")
+        if bashio::config.has_value "devices[${device}].powervalue"; then
+            upspowervalue=$(bashio::config "devices[${device}].powervalue")
+        else
+            upspowervalue="1"
+        fi
 
         bashio::log.info "Configuring Device named ${upsname}..."
         {
@@ -96,7 +101,7 @@ if bashio::config.equals 'mode' 'netserver' ;then
         done
         IFS="$OIFS"
 
-        echo "MONITOR ${upsname}@localhost 1 upsmonmaster ${upsmonpwd} master" \
+        echo "MONITOR ${upsname}@localhost ${upspowervalue} upsmonmaster ${upsmonpwd} master" \
             >> /etc/nut/upsmon.conf
     done
 


### PR DESCRIPTION
# Proposed Changes

I'm monitoring a couple of UPS that don't have any relation to supplying power to the rPI where HA is running, so I want to prevent the battery going flat on those UPS from shutting down the rPI unneccessarily (while also keeping the one UPS that **does** supply power being able to shut down the rPI) 

`nut` has a concept for this, an option called the "powervalue" in the list of `MONITOR` configs in `upsmon.conf`

That value is currently hardcoded to `1`, so all UPS that are configured will trigger shutdown if the battery gets low. 

From the docs:
```
# <powervalue> is an integer - the number of power supplies that this UPS
# feeds on this system.  Most computers only have one power supply, so this
# is normally set to 1.  You need a pretty big or special box to have any
# other value here.
#
# You can also set this to 0 for a system that doesn't supply any power,
# but you still want to monitor.  Use this when you want to hear about
# changes for a given UPS without shutting down when it goes critical,
# unless <powervalue> is 0.
```

This is my attempt to allow that to optionally be set. Since it's not related to the items commonly placed in to the `config` array on each device, I put it at the top level of teh `device`, (e.g. like `port` or `driver`)
 
Docs update is in the PR also. 

Note that this value does also allow people to introduce the concept of controlled shutdowns if they have two power supplies on their HA host. I assume there are very few people doing this, but it's an option. 

I am not experienced in how add-ons are written and tested, so I must admit this is an untested PR. 

Thanks!


## Related Issues

N/A
