### PR TITLE
list_usb_devices also displays NUT addon configuration

### DIFF
--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -199,10 +199,10 @@ allow testing without impact to the system.
 
 ### Option: `list_usb_devices`
 
-When this option is set to `true`, a list of connected USB devices will be
-displayed in the add-on log when the add-on starts up. This option can be used
-to help identify different UPS devices when multiple UPS devices are connected
-to the system.
+When this option is set to `true`, a list of connected USB devices, along with the
+configuration for devices, will be displayed in the add-on log when the add-on
+starts up. This option can be used to help identify different UPS devices when
+multiple UPS devices are connected to the system.
 
 ### Option: `remote_ups_name`
 

--- a/nut/rootfs/etc/cont-init.d/nut.sh
+++ b/nut/rootfs/etc/cont-init.d/nut.sh
@@ -25,6 +25,8 @@ sed -i "s#%%nutmode%%#${nutmode}#g" /etc/nut/nut.conf
 if bashio::config.true 'list_usb_devices' ;then
     bashio::log.info "Connected USB devices:"
     lsusb
+    bashio::log.info "NUT USB UPS configuration:"
+    nut-scanner -U
 fi
 
 if bashio::config.equals 'mode' 'netserver' ;then


### PR DESCRIPTION
# Proposed Changes

When enabling list_usb_devices option, also call nut-scanner -U, beside from lsusb, to detect supported USB devices and output the expected configuration. This should improve NUT addon usability and supportability

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: #333 #322 