### PR TITLE
Be more verbose about hostname

### DIFF
--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -15,7 +15,7 @@ many [individuals and companies][nut-acknowledgements].
 
 Be sure to add the NUT integration after starting the add-on.
 
-**Note**: _The host `a0d7b954-nut` can be used to allow Home Assistant to
+**Note**: _The host `a0d7b954-nut` has be used to allow Home Assistant to
 communicate directly with the addon_
 
 For more information on how to configure the NUT integration in Home Assistant
@@ -35,7 +35,7 @@ comparison to installing any other Home Assistant add-on.
 1. Configure the `users` and `devices` options.
 1. Start the "Network UPS Tools" add-on.
 1. Check the logs of the "Network UPS Tools" add-on to see if everything went well.
-1. Configure the [NUT Integration][nut-ha-docs].
+1. Configure the [NUT Integration][nut-ha-docs] and use `a0d7b954-nut` hostname.
 
 ## Configuration
 

--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -15,8 +15,8 @@ many [individuals and companies][nut-acknowledgements].
 
 Be sure to add the NUT integration after starting the add-on.
 
-**Note**: _The host `a0d7b954-nut` must be used to allow Home Assistant to
-communicate directly with the addon_
+**Note**: _The host `a0d7b954-nut` can be used to allow Home Assistant to
+communicate directly with the addon._
 
 For more information on how to configure the NUT integration in Home Assistant
 see the [NUT integration documentation][nut-ha-docs].
@@ -35,7 +35,7 @@ comparison to installing any other Home Assistant add-on.
 1. Configure the `users` and `devices` options.
 1. Start the "Network UPS Tools" add-on.
 1. Check the logs of the "Network UPS Tools" add-on to see if everything went well.
-1. Configure the [NUT Integration][nut-ha-docs] and use `a0d7b954-nut` hostname.
+1. Configure the [NUT Integration][nut-ha-docs] and use the container hostname like `a0d7b954-nut` as the host. You can find the specific hostname on the add-on's status page.
 
 ## Configuration
 

--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -15,7 +15,7 @@ many [individuals and companies][nut-acknowledgements].
 
 Be sure to add the NUT integration after starting the add-on.
 
-**Note**: _The host `a0d7b954-nut` has be used to allow Home Assistant to
+**Note**: _The host `a0d7b954-nut` must be used to allow Home Assistant to
 communicate directly with the addon_
 
 For more information on how to configure the NUT integration in Home Assistant


### PR DESCRIPTION
# Proposed Changes

Documentation change. The fact that add-on specific hostname has to be used in the NUT integration instead of the default `localhost` is not highlighted well and it led to several comments in tickets, e.g. [here](https://github.com/home-assistant/core/issues/75765#issuecomment-1336600731), or [here](https://github.com/home-assistant/core/issues/55888#issuecomment-1179123795). 

So I'm changing the text from /can/ to /must/ and I'm adding it to the steps to follow as well to make it less likely to be overlooked as it happened to me.

## Related Issues

- I made a similar update for the NUT integration documentation: home-assistant/home-assistant.io#31114
