### PR TITLE
🚑 Fix shutdown addon command

### DIFF
--- a/nut/rootfs/etc/cont-init.d/nut.sh
+++ b/nut/rootfs/etc/cont-init.d/nut.sh
@@ -114,7 +114,7 @@ if bashio::config.equals 'mode' 'netserver' ;then
     fi
 fi
 
-shutdowncmd="\"s6-svscanctl -t /var/run/s6/services\""
+shutdowncmd="/run/s6/basedir/bin/halt"
 if bashio::config.true 'shutdown_host'; then
     bashio::log.warning "UPS Shutdown will shutdown the host"
     shutdowncmd="/usr/bin/shutdownhost"


### PR DESCRIPTION
# Proposed Changes

Fix addon shutdown command, likely due to changes in S6 no longer functions, this aligns with the tear down commands within the service runs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated shutdown command to ensure proper system shutdown when in 'netserver' mode.
  - Adjusted shutdown command to use a specific script when `shutdown_host` is true, improving shutdown reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->