### PR TITLE
📚 Clarify powervalue settings

### DIFF
--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -151,6 +151,8 @@ wish to monitor, but you don't want low battery on some of them to shut down
 this host. Acceptable values are `1` for "providing power to this host" or `0`
 for "monitor only". Defaults to `1`
 
+**Note**: _There must be a minimum of one attached device with powervalue `1`_
+
 #### Sub-option: `config`
 
 A list of additional [options][ups-fields] to configure for this UPS. The common


### PR DESCRIPTION
# Proposed Changes

Clarify that at least one device must have powervalue 1

## Related Issues

Closes #387 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated and expanded documentation for the Network UPS Tools (NUT) add-on, including detailed configuration options for `log_level`, `users`, and `devices`.
	- Added security considerations and warnings regarding specific options.
	- Clarified event notification structure and provided examples for automation based on UPS state changes.
	- Enhanced resources in the changelog and support sections for better user engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->