### PR TITLE
Update nut package versions to 2.8.3-3 in Dockerfile

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -5,17 +5,23 @@ FROM ${BUILD_FROM}
 # Setup base
 # hadolint ignore=DL3003
 RUN \
-    apt-get update \
+    echo 'deb http://deb.debian.org/debian testing main' > /etc/apt/sources.list.d/testing.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends\
-        nut=2.8.0-7 \
-        nut-snmp=2.8.0-7 \
-        nut-xml=2.8.0-7 \
-        usbutils=1:014-1+deb12u1 \
+    nut=2.8.3-3 \
+    nut-snmp=2.8.3-3 \
+    nut-xml=2.8.3-3 \
+    usbutils=1:014-1+deb12u1 \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/testing.list
 
 # Copy root filesystem
 COPY rootfs /
+
+# Make init scripts executable
+RUN chmod +x /etc/cont-init.d/*.sh && \
+    chmod +x /etc/services.d/*/* && \
+    chmod +x /usr/bin/*
 
 # Build arguments
 ARG BUILD_ARCH


### PR DESCRIPTION
# Proposed Changes

NUT is upgraded to 2.8.3 in order to support latest configuration options such as     
```
- onlinedischarge_calibration
- lbrb_log_delay_sec = 5
- lbrb_log_delay_without_calibrating
```



