### PR TITLE
Add support for apc_modbus

### DIFF
--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -128,8 +128,7 @@ _Refer to the [`ups.conf(5)`][ups-conf] documentation for more information._
 
 #### Sub-option: `name`
 
-The name of the UPS. The name `default` is used internally, so you can’t use
-it in this file.
+The name of the UPS. You cannot use any space characters or the name `default`.
 
 #### Sub-option: `driver`
 

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -10,6 +10,7 @@ RUN \
         nut=2.8.1-5 \
         nut-snmp=2.8.1-5 \
         nut-xml=2.8.1-5 \
+        nut-modbus=2.8.1-5 \
         usbutils=1:018-2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILD_FROM}
 # hadolint ignore=DL3003
 RUN \
     apt-get update \
-    && apt-get install -y --no-install-recommends\
+    && apt-get install -y --no-install-recommends \
         nut=2.8.1-5 \
         nut-snmp=2.8.1-5 \
         nut-xml=2.8.1-5 \


### PR DESCRIPTION
Now that this add-on has been updated to Debian 13, the NUT apc_modbus driver can be supported simply by installing the nut-modbus package.

Be aware that this supports Modbus over TCP and Serial, but not USB.  Modbus over USB currently requires a patched libmodbus, which is (per previous Issues in this repo related to Modbus) out of scope for this add-on.

Fixes #367
Fixes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Modbus protocol support for UPS devices via the nut-modbus package, enabling Modbus-connected hardware.

* **Documentation**
  * Clarified device naming rules: no space characters allowed and the name “default” is not permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->