### PR TITLE
Configure NUT logging based on log_level

### DIFF
--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -60,24 +60,6 @@ shutdown_host: "false"
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
 
-### Option: `log_level`
-
-The `log_level` option controls the level of log output by the add-on and can
-be changed to be more or less verbose, which might be useful when you are
-dealing with an unknown issue. Possible values are:
-
-- `trace`: Show every detail, like all called internal functions.
-- `debug`: Shows detailed debug information.
-- `info`: Normal (usually) interesting events.
-- `warning`: Exceptional occurrences that are not errors.
-- `error`: Runtime errors that do not require immediate action.
-- `fatal`: Something went terribly wrong. Add-on becomes unusable.
-
-Please note that each level automatically includes log messages from a
-more severe level, e.g., `debug` also shows `info` messages. By default,
-the `log_level` is set to `info`, which is the recommended setting unless
-you are troubleshooting.
-
 ### Option: `users`
 
 This option allows you to specify a list of one or more users. Each user can
@@ -193,6 +175,36 @@ Recognized values are `netserver` and `netclient`.
 When this option is set to `true` on a UPS shutdown command, the host system
 will be shutdown. When set to `false` only the add-on will be stopped. This is to
 allow testing without impact to the system.
+
+### Option: `log_level`
+
+The `log_level` option controls the level of log output by the add-on's scripts,
+and sets default log levels for NUT and libusb. Possible values are:
+
+- `trace`: Log every available message/event, including (if available) things
+  like internal function calls.
+  Within NUT, this sets `debug_min = 9` and `LIBUSB_DEBUG = 4`.
+- `debug`: Log debug messages.
+  Within NUT, this sets `debug_min = 4` and `LIBUSB_DEBUG = 3`.
+- `info`: Log normal status messages / events.
+  Within NUT, this sets `debug_min = 1` and implies `LIBUSB_DEBUG = 0`.
+- `notice`: Log only important messages/events.
+  Within NUT, this implies `debug_min = 0` and `LIBUSB_DEBUG = 0`.
+- `warning`: Log only warnings and errors.
+  Within NUT, this implies `debug_min = 0` and `LIBUSB_DEBUG = 0`.
+- `error`: Log only errors.
+  Within NUT, this implies `debug_min = 0` and `LIBUSB_DEBUG = 0`.
+- `fatal`: Log only severe errors.
+  Within NUT, this implies `debug_min = 0` and `LIBUSB_DEBUG = 0`.
+
+Please note that each level automatically includes log messages from a
+more severe level, e.g., `debug` also shows `info` messages. By default,
+the `log_level` is set to `info`, which is the recommended setting unless
+you are troubleshooting.
+
+For more advanced control of logging, you can explicitly set `debug_min` and/or
+`LIBUSB_DEBUG` in the `config` sub-option of each `device`, which will override
+the values implicitly set by `log_level` for that `device`.
 
 ### Option: `list_usb_devices`
 

--- a/nut/config.yaml
+++ b/nut/config.yaml
@@ -33,8 +33,8 @@ options:
       config: []
   mode: netserver
   shutdown_host: "false"
+  log_level: info
 schema:
-  log_level: list(trace|debug|info|notice|warning|error|fatal)?
   users:
     - username: str
       password: password
@@ -52,6 +52,7 @@ schema:
         - str
   mode: list(netserver|netclient)
   shutdown_host: bool
+  log_level: list(trace|debug|info|notice|warning|error|fatal)?
   list_usb_devices: bool?
   remote_ups_name: str?
   remote_ups_host: str?

--- a/nut/rootfs/etc/cont-init.d/nut.sh
+++ b/nut/rootfs/etc/cont-init.d/nut.sh
@@ -5,14 +5,16 @@
 # ==============================================================================
 readonly USERS_CONF=/etc/nut/upsd.users
 readonly UPSD_CONF=/etc/nut/upsd.conf
+readonly UPS_CONF=/etc/nut/ups.conf
 declare nutmode
 declare password
 declare shutdowncmd
 declare upsmonpwd
 declare username
 
-chown root:root /var/run/nut
-chmod 0770 /var/run/nut
+mkdir -p /run/nut
+chown root:root /run/nut
+chmod 0770 /run/nut
 
 chown -R root:root /etc/nut
 find /etc/nut -not -perm 0660 -type f -exec chmod 0660 {} \;
@@ -76,6 +78,21 @@ if bashio::config.equals 'mode' 'netserver' ;then
         echo "MAXAGE ${maxage}" >> "${UPSD_CONF}"
     fi
 
+    debug_min=0
+    # bashio::trace is in the bashio source repo but not the current release.
+    #if bashio::trace; then
+    if [[ "${__BASHIO_LOG_LEVEL}" -ge "${__BASHIO_LOG_LEVEL_TRACE}" ]]; then
+        debug_min=9
+        export LIBUSB_DEBUG=4
+    elif bashio::debug; then
+        debug_min=4
+        export LIBUSB_DEBUG=3
+    # bashio only has functions for checking the `debug` and `trace` log levels.
+    #elif bashio::info; then
+    elif [[ "${__BASHIO_LOG_LEVEL}" -ge "${__BASHIO_LOG_LEVEL_INFO}" ]]; then
+        debug_min=1
+    fi
+
     for device in $(bashio::config "devices|keys"); do
         upsname=$(bashio::config "devices[${device}].name")
         upsdriver=$(bashio::config "devices[${device}].driver")
@@ -94,24 +111,21 @@ if bashio::config.equals 'mode' 'netserver' ;then
             echo "  port = ${upsport}"
         } >> /etc/nut/ups.conf
 
+        debug_min_set='n'
         OIFS=$IFS
         IFS=$'\n'
         for configitem in $(bashio::config "devices[${device}].config"); do
             echo "  ${configitem}" >> /etc/nut/ups.conf
+            [[ "${configitem}" =~ ^debug_min[\ \	]*= ]] && debug_min_set='y'
         done
         IFS="$OIFS"
+        if [ "${debug_min_set}" = 'n' ] && [ "${debug_min}" -ge 1 ]; then
+            echo "  debug_min = ${debug_min}" >> "${UPS_CONF}"
+        fi
 
         echo "MONITOR ${upsname}@localhost ${upspowervalue} upsmonmaster ${upsmonpwd} master" \
             >> /etc/nut/upsmon.conf
     done
-
-    bashio::log.info "Starting the UPS drivers..."
-    # Run upsdrvctl
-    if bashio::debug; then
-        upsdrvctl -u root -D start
-    else
-        upsdrvctl -u root start
-    fi
 fi
 
 shutdowncmd="/run/s6/basedir/bin/halt"

--- a/nut/rootfs/etc/services.d/upsd/finish
+++ b/nut/rootfs/etc/services.d/upsd/finish
@@ -4,7 +4,7 @@
 # Take down the S6 supervision tree when upsd fails
 # ==============================================================================
 if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
-  bashio::log.warning "upsd crashed, halting add-on"
+  bashio::log.warning "upsd crashed with exit code ${1}, halting add-on"
   /run/s6/basedir/bin/halt
 fi
 

--- a/nut/rootfs/etc/services.d/upsd/run
+++ b/nut/rootfs/etc/services.d/upsd/run
@@ -4,8 +4,14 @@
 # Run upsd
 # ==============================================================================
 if ! bashio::config.equals 'mode' 'netserver' ;then
-    exec sleep 864000
+    exec tail -f /dev/null
 fi
 
 bashio::log.info "Starting the UPS information server..."
-exec upsd -D -u root
+# bashio only has functions for checking the `debug` and `trace` log levels.
+#if bashio::info; then
+if [[ "${__BASHIO_LOG_LEVEL}" -ge "${__BASHIO_LOG_LEVEL_INFO}" ]]; then
+    exec upsd -D -u root
+else
+    exec upsd -F -u root
+fi

--- a/nut/rootfs/etc/services.d/upsdrvctl/finish
+++ b/nut/rootfs/etc/services.d/upsdrvctl/finish
@@ -1,11 +1,11 @@
 #!/command/with-contenv bashio
 # ==============================================================================
 # Home Assistant Community Add-on: Network UPS Tools
-# Take down the S6 supervision tree when upsmon fails
+# Take down the S6 supervision tree when upsdrvctl fails
 # ==============================================================================
 if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
-  bashio::log.warning "upsmon crashed with exit code ${1}, halting add-on"
+  bashio::log.warning "upsdrvctl crashed with exit code ${1}, halting add-on"
   /run/s6/basedir/bin/halt
 fi
 
-bashio::log.info "upsmon stopped, restarting..."
+bashio::log.info "upsdrvctl stopped, restarting..."

--- a/nut/rootfs/etc/services.d/upsdrvctl/run
+++ b/nut/rootfs/etc/services.d/upsdrvctl/run
@@ -1,0 +1,15 @@
+#!/command/with-contenv bashio
+# ==============================================================================
+# Home Assistant Community Add-on: Network UPS Tools
+# Run upsdrvctl
+# ==============================================================================
+if ! bashio::config.equals 'mode' 'netserver'; then
+    exec tail -f /dev/null
+fi
+
+bashio::log.info "Starting the UPS drivers..."
+if bashio::debug; then
+    exec upsdrvctl -F -u root -D start
+else
+    exec upsdrvctl -F -u root start
+fi

--- a/nut/rootfs/etc/services.d/upsmon/run
+++ b/nut/rootfs/etc/services.d/upsmon/run
@@ -8,4 +8,10 @@ if bashio::config.equals 'mode' 'netserver' ;then
 fi
 
 bashio::log.info "Starting the UPS monitor and shutdown controller..."
-exec upsmon -p -D
+# bashio only has functions for checking the `debug` and `trace` log levels.
+#if bashio::info; then
+if [[ "${__BASHIO_LOG_LEVEL}" -ge "${__BASHIO_LOG_LEVEL_INFO}" ]]; then
+    exec upsmon -p -D
+else
+    exec upsmon -p -F
+fi


### PR DESCRIPTION
# Proposed Changes

Configure NUT logging based on the add-on's `log_level` option, and run upsdrvctl in the foreground so that driver logs are captured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Relocated and expanded log_level docs with per-level mappings, debug/libusb implications, per-device override guidance, and updated startup/list_usb_devices behavior.

* **New Features**
  * Added remote UPS connection options, upsmon_deadtime, and new security-related toggles.

* **Chores / Reliability**
  * Service startup now adapts to log level; improved per-device debug propagation; enhanced service supervision and clearer exit-code warnings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->