### PR TITLE
Install I2C, IPMI, and Powerman PDU UPS drivers

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -8,9 +8,12 @@ RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         nut=2.8.1-5 \
+        nut-i2c=2.8.1-5 \
+        nut-ipmi=2.8.1-5 \
+        nut-modbus=2.8.1-5 \
+        nut-powerman-pdu=2.8.1-5 \
         nut-snmp=2.8.1-5 \
         nut-xml=2.8.1-5 \
-        nut-modbus=2.8.1-5 \
         usbutils=1:018-2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Proposed Changes

(I'm splitting https://github.com/hassio-addons/addon-nut/pull/472 into multiple PRs; This is one of those PRs)

Install the NUT I2C, IPMI, and Powerman PDU drivers.

Fixes #453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended NUT service support to include I2C, IPMI, Modbus and PowerMan PDU device types.

* **Chores**
  * Removed a duplicate package entry and consolidated installation of NUT-related packages for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->