### PR TITLE
Deprecate master/slave terminology in favor of primary/secondary

### DIFF
--- a/nut/DOCS.md
+++ b/nut/DOCS.md
@@ -112,8 +112,8 @@ The list of actions is expected to grow in the future.
 #### Sub-option: `upsmon`
 
 Add the necessary actions for a `upsmon` process to work. This is either set to
-`master` or `slave`. If creating an account for a `netclient` setup to connect
-this should be set to `slave`.
+`primary` or `secondary`. If creating an account for a `netclient` setup to connect
+this should be set to `secondary`.
 
 ### Option: `devices`
 
@@ -184,7 +184,7 @@ devices:
 Recognized values are `netserver` and `netclient`.
 
 - `netserver`: Runs the components needed to manage a locally connected UPS and
-  allow other clients to connect (either as slaves or for management).
+  allow other clients to connect (either as secondaries or for management).
 - `netclient`: Only runs `upsmon` to connect to a remote system running as
   `netserver`.
 
@@ -267,7 +267,7 @@ See the below table for more information as well as the message that will be in
 | `ONLINE`   | UPS is back online                                                    | "UPS %s on line power"                             |
 | `ONBATT`   | UPS is on battery                                                     | "UPS %s on battery"                                |
 | `LOWBATT`  | UPS has a low battery (if also on battery, it's "critical")           | "UPS %s battery is low"                            |
-| `FSD`      | UPS is being shutdown by the master (FSD = "Forced Shutdown")         | "UPS %s: forced shutdown in progress"              |
+| `FSD`      | UPS is being shutdown by the primary (FSD = "Forced Shutdown")        | "UPS %s: forced shutdown in progress"              |
 | `COMMOK`   | Communications established with the UPS                               | "Communications with UPS %s established"           |
 | `COMMBAD`  | Communications lost to the UPS                                        | "Communications with UPS %s lost"                  |
 | `SHUTDOWN` | The system is being shutdown                                          | "Auto logout and shutdown proceeding"              |

--- a/nut/config.yaml
+++ b/nut/config.yaml
@@ -42,7 +42,7 @@ schema:
         - str
       actions:
         - str
-      upsmon: list(master|slave)?
+      upsmon: list(primary|secondary|master|slave)?
   devices:
     - name: str
       driver: str

--- a/nut/rootfs/etc/cont-init.d/nut.sh
+++ b/nut/rootfs/etc/cont-init.d/nut.sh
@@ -38,7 +38,7 @@ if bashio::config.equals 'mode' 'netserver' ;then
         echo
         echo "[upsmonmaster]"
         echo "  password = ${upsmonpwd}"
-        echo "  upsmon master"
+        echo "  upsmon primary"
     } >> "${USERS_CONF}"
 
     for user in $(bashio::config "users|keys"); do
@@ -69,6 +69,8 @@ if bashio::config.equals 'mode' 'netserver' ;then
 
         if bashio::config.has_value "users[${user}].upsmon"; then
             upsmon=$(bashio::config "users[${user}].upsmon")
+            [[ "${upsmon}" == "master" ]] && upsmon="primary"
+            [[ "${upsmon}" == "slave" ]] && upsmon="secondary"
             echo "  upsmon ${upsmon}" >> "${USERS_CONF}"
         fi
     done
@@ -103,7 +105,7 @@ if bashio::config.equals 'mode' 'netserver' ;then
         done
         IFS="$OIFS"
 
-        echo "MONITOR ${upsname}@localhost ${upspowervalue} upsmonmaster ${upsmonpwd} master" \
+        echo "MONITOR ${upsname}@localhost ${upspowervalue} upsmonmaster ${upsmonpwd} primary" \
             >> /etc/nut/upsmon.conf
     done
 

--- a/nut/rootfs/etc/cont-init.d/nutclient.sh
+++ b/nut/rootfs/etc/cont-init.d/nutclient.sh
@@ -18,7 +18,7 @@ if bashio::config.equals 'mode' 'netclient' ;then
     rhost=$(bashio::config "remote_ups_host")
     ruser=$(bashio::config "remote_ups_user")
     rpwd=$(bashio::config "remote_ups_password")
-    echo "MONITOR ${rname}@${rhost} 1 ${ruser} ${rpwd} slave" \
+    echo "MONITOR ${rname}@${rhost} 1 ${ruser} ${rpwd} secondary" \
         >> /etc/nut/upsmon.conf
 fi
 


### PR DESCRIPTION
# Proposed Changes

NUT 2.8.x deprecated the master/slave role terminology in favor of primary/secondary. This aligns the add-on with that change.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now accepts both new (`primary`/`secondary`) and legacy (`master`/`slave`) upsmon role values with automatic normalization.

* **Documentation**
  * Updated upsmon role terminology from `master`/`slave` to `primary`/`secondary` across documentation and configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->