### PR TITLE
Fix directory permissions for /etc/nut

### DIFF
--- a/nut/rootfs/etc/cont-init.d/nut.sh
+++ b/nut/rootfs/etc/cont-init.d/nut.sh
@@ -18,7 +18,7 @@ chmod 0770 /run/nut
 
 chown -R root:root /etc/nut
 find /etc/nut -not -perm 0660 -type f -exec chmod 0660 {} \;
-find /etc/nut -not -perm 0660 -type d -exec chmod 0660 {} \;
+find /etc/nut -not -perm 0770 -type d -exec chmod 0770 {} \;
 
 nutmode=$(bashio::config 'mode')
 bashio::log.info "Setting mode to ${nutmode}..."


### PR DESCRIPTION
# Proposed Changes

The find command setting permissions on /etc/nut was using 0660 for both files and directories. Directories need the execute bit to be traversable, so they should be 0770, not 0660. Files remain 0660 as intended.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system directory permissions in container initialization to improve access control for service components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->