### PR TITLE
Declare upsmon variable explicitly in nut.sh

### DIFF
--- a/nut/rootfs/etc/cont-init.d/nut.sh
+++ b/nut/rootfs/etc/cont-init.d/nut.sh
@@ -8,6 +8,7 @@ readonly UPSD_CONF=/etc/nut/upsd.conf
 declare nutmode
 declare password
 declare shutdowncmd
+declare upsmon
 declare upsmonpwd
 declare username
 


### PR DESCRIPTION
# Proposed Changes

The upsmon variable was used without a prior declare, inconsistent with the rest of the script. Added the missing declaration alongside the other variables at the top.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
