### PR TITLE
Fix indentation of bashio::exit.nok in nutclient.sh

### DIFF
--- a/nut/rootfs/etc/cont-init.d/nutclient.sh
+++ b/nut/rootfs/etc/cont-init.d/nutclient.sh
@@ -9,8 +9,8 @@ declare -a CONF_ENTRIES=("name" "host" "password" "user")
 if bashio::config.equals 'mode' 'netclient' ;then
     for entry in "${CONF_ENTRIES[@]}"; do
         if ! bashio::config.exists "remote_ups_${entry}";then
-        bashio::exit.nok \
-            "Netclient mode specified but no ${entry} is configured"
+            bashio::exit.nok \
+                "Netclient mode specified but no ${entry} is configured"
         fi
     done
 


### PR DESCRIPTION
# Proposed Changes

bashio::exit.nok was not indented inside its if block, making the code misleading to read. Fixed to be consistently indented with the rest of the script.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
