### PR TITLE
Add nutdrv_hashx driver support

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -13,6 +13,7 @@ RUN \
         autoconf=2.72-3.1 \
         automake=1:1.17-4 \
         build-essential=12.12 \
+        libhidapi-dev=0.14.0-1+b2 \
         libltdl-dev=2.5.4-4 \
         libmodbus-dev=3.1.11-2 \
         libsnmp-dev=5.9.4+dfsg-2+deb13u1 \
@@ -36,7 +37,7 @@ RUN \
     && tar -xzvf "${NUT_FILENAME}" \
     && cd "${NUT_FILENAME%.tar.gz}" \
     && ./configure --prefix=/usr --datadir=/usr/share/nut --sysconfdir=/etc/nut --with-drvpath=/usr/libexec/nut \
-        --with-usb --with-modbus --with-snmp --with-ssl \
+        --with-usb --with-hidapi --with-modbus --with-snmp --with-ssl \
     && make \
     && make DESTDIR=/app install
 
@@ -51,6 +52,7 @@ COPY --from=builder /app /
 # Setup app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        libhidapi-hidraw0=0.14.0-1+b2 \
         libmodbus5=3.1.11-2 \
         libsnmp40t64=5.9.4+dfsg-2+deb13u1 \
         libusb-1.0-0=2:1.0.28-1 \


### PR DESCRIPTION
# Proposed Changes

nutdrv_hashx uses libhidapi for HID communication rather than the standard libusb-1.0 interface. Without libhidapi-dev in the builder and --with-hidapi in the configure flags, the driver was silently skipped at compile time and simply absent from the image.

## Related Issues

fixes #488.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HIDAPI driver support is now enabled, improving compatibility with a broader range of hardware devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->