### PR TITLE
Supervise UPS driver processes with s6 for automatic recovery

### DIFF
--- a/nut/rootfs/etc/cont-init.d/nut.sh
+++ b/nut/rootfs/etc/cont-init.d/nut.sh
@@ -108,15 +108,25 @@ if bashio::config.equals 'mode' 'netserver' ;then
 
         echo "MONITOR ${upsname}@localhost ${upspowervalue} upsmonmaster ${upsmonpwd} primary" \
             >> /etc/nut/upsmon.conf
-    done
 
-    bashio::log.info "Starting the UPS drivers..."
-    # Run upsdrvctl
-    if bashio::debug; then
-        upsdrvctl -u root -D start
-    else
-        upsdrvctl -u root start
-    fi
+        bashio::log.info "Registering supervised driver service for ${upsname}..."
+        mkdir -p "/etc/services.d/nut-driver-${upsname}"
+        {
+            echo "#!/command/with-contenv bashio"
+            echo "if bashio::debug; then"
+            echo "    exec /usr/libexec/nut/${upsdriver} -F -D -u root -a ${upsname}"
+            echo "else"
+            echo "    exec /usr/libexec/nut/${upsdriver} -F -u root -a ${upsname}"
+            echo "fi"
+        } > "/etc/services.d/nut-driver-${upsname}/run"
+        chmod +x "/etc/services.d/nut-driver-${upsname}/run"
+
+        {
+            echo "#!/command/with-contenv bashio"
+            echo "bashio::log.warning \"UPS driver for ${upsname} stopped, restarting...\""
+        } > "/etc/services.d/nut-driver-${upsname}/finish"
+        chmod +x "/etc/services.d/nut-driver-${upsname}/finish"
+    done
 fi
 
 shutdowncmd="/run/s6/basedir/bin/halt"


### PR DESCRIPTION
# Proposed Changes

Previously, UPS drivers were started once via upsdrvctl during container init and left completely unsupervised. When a driver died (due to a USB disconnect, HA update, or any other transient issue) nothing restarted it. upsd would mark the data as stale indefinitely, requiring a manual add-on restart to recover.

This change generates a dedicated s6 service directory for each configured UPS device at init time. Each driver runs in foreground mode (-F) under s6 supervision. When a driver exits for any reason, s6 automatically restarts it. Since upsd retries driver socket connections on each poll cycle, recovery is fully automatic once the driver comes back up.

## Related Issues

fixes #452
fixes #483
fixes #418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * UPS driver management now uses service supervision for each configured device instead of one-time startup. Drivers are automatically monitored and restarted if they stop unexpectedly, improving system reliability and reducing potential monitoring downtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->