### PR TITLE
Fix: nutdrv_hashx is compiled with HID/USB support

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -37,9 +37,10 @@ RUN \
     && tar -xzvf "${NUT_FILENAME}" \
     && cd "${NUT_FILENAME%.tar.gz}" \
     && ./configure --prefix=/usr --datadir=/usr/share/nut --sysconfdir=/etc/nut --with-drvpath=/usr/libexec/nut \
-        --with-usb --with-hidapi --with-modbus --with-snmp --with-ssl \
+       --with-usb --with-hidapi --with-modbus --with-snmp --with-ssl --with-drivers=all \
     && make \
-    && make DESTDIR=/app install
+    && make DESTDIR=/app install \
+    && /app/usr/libexec/nut/nutdrv_hashx -h 2>&1 | grep -q "usb" || { echo "ERROR: nutdrv_hashx compiled without USB support"; exit 1; }
 
 FROM base AS app
 

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -41,8 +41,17 @@ RUN \
         --with-usb --with-hidapi --with-modbus --with-snmp --with-ssl --with-drivers=all \
     && make \
     && make DESTDIR=/app install \
-    && if ! /app/usr/libexec/nut/nutdrv_hashx -h 2>&1 | grep -q "usb"; then \
-        echo "ERROR: nutdrv_hashx compiled without USB support"; exit 1; \
+    && NUTDRV_HASHX_HELP_OUTPUT="$(/app/usr/libexec/nut/nutdrv_hashx -h 2>&1)" \
+    && NUTDRV_HASHX_HELP_STATUS="$?" \
+    && if [ "${NUTDRV_HASHX_HELP_STATUS}" -ne 0 ]; then \
+        echo "ERROR: nutdrv_hashx -h exited with status ${NUTDRV_HASHX_HELP_STATUS}"; \
+        echo "${NUTDRV_HASHX_HELP_OUTPUT}"; \
+        exit 1; \
+    fi \
+    && if ! printf '%s\n' "${NUTDRV_HASHX_HELP_OUTPUT}" | grep -qi "usb"; then \
+        echo "ERROR: nutdrv_hashx compiled without USB support"; \
+        echo "${NUTDRV_HASHX_HELP_OUTPUT}"; \
+        exit 1; \
     fi
 
 FROM base AS app

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -27,8 +27,8 @@ RUN \
 
 # hadolint ignore=DL3003
 RUN \
-    mkdir -p /app /build \
-    && set -o pipefail \
+    set -o pipefail \
+    && mkdir -p /app /build \
     && cd /build \
     && NUT_FILENAME="nut-${NUT_VERSION}.tar.gz" \
     && NUT_DOWNLOAD_URL="https://github.com/networkupstools/nut/releases/download/v${NUT_VERSION}/${NUT_FILENAME}" \
@@ -38,7 +38,7 @@ RUN \
     && tar -xzvf "${NUT_FILENAME}" \
     && cd "${NUT_FILENAME%.tar.gz}" \
     && ./configure --prefix=/usr --datadir=/usr/share/nut --sysconfdir=/etc/nut --with-drvpath=/usr/libexec/nut \
-       --with-usb --with-hidapi --with-modbus --with-snmp --with-ssl --with-drivers=all \
+        --with-usb --with-hidapi --with-modbus --with-snmp --with-ssl --with-drivers=all \
     && make \
     && make DESTDIR=/app install \
     && if ! /app/usr/libexec/nut/nutdrv_hashx -h 2>&1 | grep -q "usb"; then \

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -28,6 +28,7 @@ RUN \
 # hadolint ignore=DL3003
 RUN \
     mkdir -p /app /build \
+    && set -o pipefail \
     && cd /build \
     && NUT_FILENAME="nut-${NUT_VERSION}.tar.gz" \
     && NUT_DOWNLOAD_URL="https://github.com/networkupstools/nut/releases/download/v${NUT_VERSION}/${NUT_FILENAME}" \
@@ -40,7 +41,9 @@ RUN \
        --with-usb --with-hidapi --with-modbus --with-snmp --with-ssl --with-drivers=all \
     && make \
     && make DESTDIR=/app install \
-    && /app/usr/libexec/nut/nutdrv_hashx -h 2>&1 | grep -q "usb" || { echo "ERROR: nutdrv_hashx compiled without USB support"; exit 1; }
+    && if ! /app/usr/libexec/nut/nutdrv_hashx -h 2>&1 | grep -q "usb"; then \
+        echo "ERROR: nutdrv_hashx compiled without USB support"; exit 1; \
+    fi
 
 FROM base AS app
 

--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -25,10 +25,9 @@ RUN \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# hadolint ignore=DL3003
+# hadolint ignore=DL3003,SC2039,DL4006
 RUN \
-    set -o pipefail \
-    && mkdir -p /app /build \
+    mkdir -p /app /build \
     && cd /build \
     && NUT_FILENAME="nut-${NUT_VERSION}.tar.gz" \
     && NUT_DOWNLOAD_URL="https://github.com/networkupstools/nut/releases/download/v${NUT_VERSION}/${NUT_FILENAME}" \


### PR DESCRIPTION
The nutdrv_hashx driver was being compiled without HID/USB support, defaulting to Serial-only mode (v0.03) and rejecting HID configuration flags.

# Proposed Changes

Adds --with-drivers=all to ensure the multi-bus capabilities of nutdrv_hashx are included.

Implements a build-time assertion to verify that the nutdrv_hashx binary actually supports USB. If the binary is compiled without USB support, the build will now explicitly fail instead of producing a broken add-on.

## Related Issues

https://github.com/hassio-addons/app-nut/issues/502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded device driver coverage in the container image for broader hardware support.
  * Added build-time validation to ensure USB driver support is present; image build will fail if USB support is missing.
  * Improved build reliability so failures are detected and propagated during image creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->