### PR TITLE
Track Debian apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,16 +30,21 @@
       "managerFilePatterns": ["//Dockerfile$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
+        "\\s\\s(?<package>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{package}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     }
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Same change as [hassio-addons/app-vaultwarden#447](https://github.com/hassio-addons/app-vaultwarden/pull/447), applied here.

Repology has become unreliable as a datasource lately: throttling, timeouts, and missing packages. It also forces us to map binary package names onto source package names.

Renovate ships a native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) that reads the Debian package indices directly, so this switches the apt pins over to it. It indexes **binary** package names, which means `depNameTemplate` becomes plain `{{{package}}}` and the whole name mapping problem disappears.

The registry URLs are a one to one mirror of the apt sources in `ghcr.io/hassio-addons/debian-base:9.4.0`:

| Source | Suite | Component |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

The `deb` datasource uses a `merge` registry strategy, so releases from all three are aggregated rather than first one wins.

**Additionally**, this widens the package name pattern in the same custom manager from `[a-z0-9][a-z0-9-]+` to `[a-z0-9][a-z0-9+.-]+`. Debian binary package names may contain `.` and `+`, and the old pattern silently skipped two of our pins: `libusb-1.0-0-dev` and `libusb-1.0-0` were never tracked by Renovate at all. With the wider pattern the manager picks up all 18 apt pins in `nut/Dockerfile` and nothing else.

### Known limitation

The datasource currently hardcodes `Packages.gz`, but `trixie-updates` and `trixie-security` serve only `Packages.xz` (verified again while preparing this: both return 404 for `Packages.gz`, while plain `trixie` returns 200). Those two suites are therefore inert for now. This fails gracefully: lookups are caught and skipped per component, so `trixie` `main` keeps working, and the other two start working by themselves once renovatebot/renovate#44330 is resolved. They are kept in the config so it stays a truthful description of what the image actually pulls from.

Unlike app-vaultwarden, which had `libpq5` pinned ahead of `main` from `trixie-security`, this repository has no such case today. I cross-checked all 18 pins against the three suite indices, and every one of them resolves from `trixie` `main` at exactly the version currently pinned. Four of them (`libssl-dev`, `libsnmp-dev`, `libsnmp40t64`, `libxml2`/`libxml2-dev`) also appear in `trixie-security`, but at identical versions, so nothing is missed right now. If security ever gets ahead of `main` for one of those, that pin would need a manual bump until the next point release folds it in, the same way `libpq5` does over there.

Validated with `renovate-config-validator` from Renovate 44.33.2.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Ports [hassio-addons/app-vaultwarden#447](https://github.com/hassio-addons/app-vaultwarden/pull/447).

Upstream: renovatebot/renovate#44330

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated tracking of Debian package updates.
  * Expanded support for package names containing plus signs and periods.
  * Added explicit update sources for Debian Trixie, Trixie Updates, and Trixie Security packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->