### PR TITLE
Ship libltdl7 so nut-scanner runs, drop unused hidapi build deps

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -13,7 +13,6 @@ RUN \
         autoconf=2.72-3.1 \
         automake=1:1.17-4 \
         build-essential=12.12 \
-        libhidapi-dev=0.14.0-1+b2 \
         libltdl-dev=2.5.4-4 \
         libmodbus-dev=3.1.11-2 \
         libsnmp-dev=5.9.4+dfsg-2+deb13u1 \
@@ -37,7 +36,7 @@ RUN \
     && tar -xzvf "${NUT_FILENAME}" \
     && cd "${NUT_FILENAME%.tar.gz}" \
     && ./configure --prefix=/usr --datadir=/usr/share/nut --sysconfdir=/etc/nut --with-drvpath=/usr/libexec/nut \
-        --with-usb --with-hidapi --with-modbus --with-snmp --with-ssl \
+        --with-usb --with-modbus --with-snmp --with-ssl \
     && make \
     && make DESTDIR=/app install
 
@@ -52,7 +51,7 @@ COPY --from=builder /app /
 # Setup app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        libhidapi-hidraw0=0.14.0-1+b2 \
+        libltdl7=2.5.4-4 \
         libmodbus5=3.1.11-2 \
         libsnmp40t64=5.9.4+dfsg-2+deb13u1 \
         libusb-1.0-0=2:1.0.28-1 \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Two related packaging fixes in `nut/Dockerfile`, both found while looking into #504.

**`nut-scanner` is shipped, but cannot run**

ca81537 dropped `--with-nut-scanner` from `./configure` and removed `libltdl7` from the app stage. But `configure --help` shows the option defaults to **auto**, and `libltdl-dev` is still present in the builder stage, so nut-scanner is still built and still installed into the image. Only its runtime library went away, leaving a binary that dies immediately:

```
$ ldd /usr/bin/nut-scanner
	libltdl.so.7 => not found
```

That was the only unresolved library across every NUT binary in the image. This restores `libltdl7` to the runtime dependencies, which is the option that keeps the tool usable, rather than `--with-nut-scanner=no`. It is the tool people reach for to discover SNMP devices, and #504 has a report of exactly that.

After the change:

```
$ nut-scanner -V
Network UPS Tools nut-scanner 2.8.5 release
```

**`--with-hidapi` does nothing**

8abd58e added `--with-hidapi`, `libhidapi-dev` and `libhidapi-hidraw0` when `nutdrv_hashx` support was introduced. None of it is used:

- `hidapi` does not appear anywhere in NUT's `configure.ac`, so autoconf silently ignores the unknown `--with-*` flag.
- `nutdrv_hashx` is a **serial** driver: `nutdrv_hashx_LDADD = $(LDADD_DRIVERS_SERIAL)` in `drivers/Makefile.am`, and `ldd` on the built binary shows only libc. It is built as part of the unconditional serial driver list either way.

So the flag and both packages are dropped.

**Verification**

Built the image before and after and compared the installed driver sets: identical, 69 drivers both ways, `nutdrv_hashx` included. After the change no NUT binary in the image has an unresolved shared library.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Addresses the `nut-scanner` half of #504. The USB restart loop reported there is a separate upstream NUT bug and is handled separately.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application image dependencies and configuration for a leaner runtime.
  * Improved runtime compatibility by including the required shared library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->