### PR TITLE
Patch NUT 2.8.5 usbhid-ups out-of-bounds read causing driver segfaults

### DIFF
--- a/nut/Dockerfile
+++ b/nut/Dockerfile
@@ -6,6 +6,9 @@ FROM base AS builder
 
 ARG NUT_VERSION=2.8.5
 
+# Patches applied to the NUT source before building
+COPY patches /patches
+
 # Setup builder
 RUN \
     apt-get update \
@@ -20,6 +23,7 @@ RUN \
         libusb-1.0-0-dev=2:1.0.28-1 \
         libxml2-dev=2.12.7+dfsg+really2.9.14-2.1+deb13u3 \
         libtool=2.5.4-4 \
+        patch=2.8-2 \
         pkg-config=1.8.1-4 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -35,6 +39,10 @@ RUN \
     && sha256sum --check "${NUT_FILENAME}.sha256" \
     && tar -xzvf "${NUT_FILENAME}" \
     && cd "${NUT_FILENAME%.tar.gz}" \
+    && for nut_patch in /patches/*.patch; do \
+        echo "Applying ${nut_patch}..." \
+        && patch -p1 --batch --forward -i "${nut_patch}"; \
+    done \
     && ./configure --prefix=/usr --datadir=/usr/share/nut --sysconfdir=/etc/nut --with-drvpath=/usr/libexec/nut \
         --with-usb --with-modbus --with-snmp --with-ssl \
     && make \

--- a/nut/patches/0001-libusb-bound-rdlens-loop-by-element-count.patch
+++ b/nut/patches/0001-libusb-bound-rdlens-loop-by-element-count.patch
@@ -1,0 +1,85 @@
+From edc06fb39435b892d5daeec53cb4845cb12d1d50 Mon Sep 17 00:00:00 2001
+From: John Grant <john.grant@dronedeploy.com>
+Date: Tue, 28 Jul 2026 20:37:49 +1200
+Subject: [PATCH] drivers/libusb{0,1}.c: bound rdlens loop by element count,
+ not sizeof [#3136]
+
+nut_libusb_open() iterates the two candidate HID report descriptor lengths:
+
+	int32_t rdlen1, rdlen2, rdlens[2];
+	size_t j;
+	...
+	for (j = 0; j < sizeof(rdlens); j++)
+
+sizeof(rdlens) is 8 (bytes), not 2 (elements), so the loop reads
+rdlens[2..7] - 24 bytes past the end of the array - and uses that stack
+garbage as rdlen. The "ran out of candidates" check after the loop has
+the same bug.
+
+The out-of-range indices are only reached when neither real candidate
+satisfies the caller, i.e. exactly when a device is in a bad state and
+both descriptor reads fail. Garbage that happens to pass the rdlen sanity
+checks is then handed to libusb_control_transfer() and on to the HID
+parser callback, which is where it segfaults.
+
+Seen with usbhid-ups against an EcoFlow DELTA 3 Plus (3746:ffff) on an
+NVIDIA Jetson Orin Nano whose USB device had wedged; "usbreset" on the
+device cleared the wedge and hid the crash.
+
+Use SIZEOF_ARRAY() from common.h, which both files already include.
+libusb0.c carries the identical defect and is fixed the same way.
+
+Regression from aba6f43544b17d2f16e69ca19f162c6c19748fc7 ("if the tried
+'rdlen' did not succeed, fall back to the other value we had in mind"),
+first released in v2.8.5.
+
+Signed-off-by: John Grant <john.grant@dronedeploy.com>
+---
+ drivers/libusb0.c | 4 ++--
+ drivers/libusb1.c | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/libusb0.c b/drivers/libusb0.c
+index 52f08f2a98..8471136efb 100644
+--- a/drivers/libusb0.c
++++ b/drivers/libusb0.c
+@@ -651,7 +651,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
+ 				}
+ 			}
+ 
+-			for (j = 0; j < sizeof(rdlens); j++) {
++			for (j = 0; j < SIZEOF_ARRAY(rdlens); j++) {
+ 				rdlen = rdlens[j];
+ 				if (rdlen < 0)
+ 					continue;
+@@ -716,7 +716,7 @@ static int nut_libusb_open(usb_dev_handle **udevp,
+ 				break;
+ 			}
+ 
+-			if (j >= sizeof(rdlens)) {
++			if (j >= SIZEOF_ARRAY(rdlens)) {
+ 				/* Ended the loop without success */
+ 				goto next_device;
+ 			}
+diff --git a/drivers/libusb1.c b/drivers/libusb1.c
+index b02da58a2f..e9f6c855c4 100644
+--- a/drivers/libusb1.c
++++ b/drivers/libusb1.c
+@@ -807,7 +807,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
+ 			}
+ 		}
+ 
+-		for (j = 0; j < sizeof(rdlens); j++) {
++		for (j = 0; j < SIZEOF_ARRAY(rdlens); j++) {
+ 			rdlen = rdlens[j];
+ 			if (rdlen < 0)
+ 				continue;
+@@ -897,7 +897,7 @@ static int nut_libusb_open(libusb_device_handle **udevp,
+ 			break;
+ 		}
+ 
+-		if (j >= sizeof(rdlens)) {
++		if (j >= SIZEOF_ARRAY(rdlens)) {
+ 			/* Ended the loop without success */
+ 			goto next_device;
+ 		}


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)




This applies an upstream NUT fix to the source we compile, to address the driver restart loop reported in #504.

**The bug**

In `drivers/libusb1.c`, `nut_libusb_open()` iterates the two candidate HID report descriptor lengths:

```c
int32_t rdlen1, rdlen2, rdlens[2];
size_t j;
...
for (j = 0; j < sizeof(rdlens); j++) {
	rdlen = rdlens[j];
```

`sizeof(rdlens)` is 8 (bytes), not 2 (elements), so the loop reads `rdlens[2..7]` — 24 bytes past the end of the array — and uses that stack garbage as `rdlen`. The "ran out of candidates" check afterwards has the same defect, so it never fires as intended either. Garbage that happens to survive the sanity checks is handed to `libusb_control_transfer()` and on to the HID parser callback, which is where it crashes. `drivers/libusb0.c` carries the identical defect in the same two places.

The out-of-range indices are only reached when *neither* real candidate satisfies the caller, which is exactly the state the reports in #504 describe: `string descriptor 0 request failed`, `get Manufacturer string failed`, `get Product string failed`, `get Serial Number string failed`, and upstream's `device->Product is NULL`.

**Why it lines up with the 0.18.0 boundary**

This is a regression from aba6f43 ([#3136](https://github.com/networkupstools/nut/issues/3136)), **first released in NUT v2.8.5**. v0.17.0 of this app shipped Debian's NUT 2.8.1 packages; v0.18.0 switched to building 2.8.5 from source. That is why downgrading to v0.17.0 makes the restart loop go away for everyone in that thread, and why no configuration change affects it.

**Why a patch rather than a version bump**

Fixed upstream in [edc06fb](https://github.com/networkupstools/nut/commit/edc06fb39435b892d5daeec53cb4845cb12d1d50), merged 2026-07-30. But v2.8.5 (April 2026) is still the latest NUT release, so there is nothing to bump to yet. The patch can be dropped again when 2.8.6 lands.

The patch file is vendored under `nut/patches/` rather than fetched at build time, so the build stays hermetic and the change is reviewable in the diff, consistent with how the release tarball is already checksum verified. The build step applies every `*.patch` in that directory in sorted order, with `--forward`, so a patch that has become redundant fails the build loudly instead of being silently skipped. `patch` is pinned explicitly in the builder rather than relying on it arriving transitively via `build-essential` → `dpkg-dev`.

**Verification**

- Confirmed the defect is present in the exact `nut-2.8.5.tar.gz` we compile (`drivers/libusb1.c:726` and `:816`, `drivers/libusb0.c:661` and `:726`).
- Confirmed the patch applies during the build and that the compiled tree has `SIZEOF_ARRAY(rdlens)` in all four places.
- Full image builds; no NUT binary has an unresolved shared library; the driver set is unchanged at 69 drivers.

> [!IMPORTANT]
> I have no affected UPS hardware, so I could not reproduce the crash or confirm first hand that this stops it. The source-level defect, its 2.8.5-only provenance, and the log signatures in #504 all line up, but it would be good to have one of the reporters confirm against a build of this branch before we call #504 fixed.

**Not fixed here**

`invalid libusb bus number 0`, which appears throughout #504, is a red herring. Despite the wording it reports `libusb_get_port_number()` returning 0, not the bus number, and it is `upsdebugx(1)`-only and harmless (`drivers/libusb1.c:398-410`). #504 has also accumulated several unrelated problems (the integration's `localhost` host setting, an SNMP case, "no UPS definitions in ups.conf", a pwned-password startup exit) that want splitting into their own issues.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Addresses the USB restart loop in #504.
Follows #527.
Upstream: networkupstools/nut#3422, networkupstools/nut#3550.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB device detection reliability by preventing invalid memory access during device discovery.
  * Corrected device candidate handling to ensure all supported entries are evaluated properly.

* **Build Improvements**
  * Added support for applying source patches automatically during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->